### PR TITLE
Pass original register value to write_op from WRITEOPR macro

### DIFF
--- a/hw/mips/pic32_peripherals.h
+++ b/hw/mips/pic32_peripherals.h
@@ -173,5 +173,4 @@ int pic32_load_hex_file(const char *filename,
                         case name+4: *namep = #name"CLR"; goto op_##name;\
                         case name+8: *namep = #name"SET"; goto op_##name;\
                         case name+12: *namep = #name"INV"; op_##name: \
-                        VALUE(name) &= romask; \
-                        VALUE(name) |= write_op(VALUE(name), data, offset) & ~(romask)
+                        VALUE(name) = (VALUE(name) & (romask)) | (write_op(VALUE(name), data, offset) & ~(romask))


### PR DESCRIPTION
The original value is needed for SET, CLR and INV operations to work correctly
