### PR TITLE
Backport fix for newer versions of glibc to resolve major() minor() definition issues

### DIFF
--- a/configure
+++ b/configure
@@ -4224,6 +4224,20 @@ if ! compile_object "-Werror"; then
 fi
 
 ##########################################
+# check for sysmacros.h
+
+have_sysmacros=no
+cat > $TMPC << EOF
+#include <sys/sysmacros.h>
+int main(void) {
+    return makedev(0, 0);
+}
+EOF
+if compile_prog "" "" ; then
+    have_sysmacros=yes
+fi
+
+##########################################
 # End of CC checks
 # After here, no more $cc or $ld runs
 
@@ -5026,6 +5040,10 @@ echo "CONFIG_TRACE_FILE=$trace_file" >> $config_host_mak
 
 if test "$rdma" = "yes" ; then
   echo "CONFIG_RDMA=y" >> $config_host_mak
+fi
+
+if test "$have_sysmacros" = "yes" ; then
+  echo "CONFIG_SYSMACROS=y" >> $config_host_mak
 fi
 
 # Hold two types of flag:

--- a/include/sysemu/os-posix.h
+++ b/include/sysemu/os-posix.h
@@ -28,6 +28,10 @@
 
 #include <sys/time.h>
 
+#ifdef CONFIG_SYSMACROS
+#include <sys/sysmacros.h>
+#endif
+
 void os_set_line_buffering(void);
 void os_set_proc_name(const char *s);
 void os_setup_signal_handling(void);


### PR DESCRIPTION
This backports https://github.com/qemu/qemu/commit/4d04351f4c3db3b70dc21f7fdc8155e341f39916
This allows us to build with modern version of glibc.

For example on my Fedora 33:
```
❯ ./configure --target-list=mipsel-softmmu --python=/usr/bin/python2 --disable-werror
❯ ./mipsel-softmmu/qemu-system-mipsel   -machine pic32mx7-explorer16   -nographic -monitor none   -serial stdio   -kernel  ~/nuttx/wrk/nuttx/nuttx.hex 
Board: Microchip Explorer16
Processor: M4K
RAM size: 128 kbytes
Load file: '/home/bashton/nuttx/wrk/nuttx/nuttx.hex', 250268 bytes
nx_start: Entry
```

Original patch context
```
The definition of the major() and minor() macros are moving within glibc to
<sys/sysmacros.h>. Include this header when it is available to avoid the
following sorts of build-stopping messages:

qga/commands-posix.c: In function ‘dev_major_minor’:
qga/commands-posix.c:656:13: error: In the GNU C Library, "major" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "major", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "major", you should undefine it after including <sys/types.h>. [-Werror]
         *devmajor = major(st.st_rdev);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~

qga/commands-posix.c:657:13: error: In the GNU C Library, "minor" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "minor", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "minor", you should undefine it after including <sys/types.h>. [-Werror]
         *devminor = minor(st.st_rdev);
```