### PR TITLE
Add missing timer stubs to pic32mx

### DIFF
--- a/hw/mips/mips_pic32mx7.c
+++ b/hw/mips/mips_pic32mx7.c
@@ -450,6 +450,25 @@ static void io_reset(pic32_t *s)
         s->spi[i].rfifo = 0;
         s->spi[i].wfifo = 0;
     }
+
+    /*
+     * Reset timers.
+     */
+    VALUE(T1CON)    = 0;
+    VALUE(TMR1)     = 0;
+    VALUE(PR1)      = 0xffff;
+    VALUE(T2CON)    = 0;
+    VALUE(TMR2)     = 0;
+    VALUE(PR2)      = 0xffff;
+    VALUE(T3CON)    = 0;
+    VALUE(TMR3)     = 0;
+    VALUE(PR3)      = 0xffff;
+    VALUE(T4CON)    = 0;
+    VALUE(TMR4)     = 0;
+    VALUE(PR4)      = 0xffff;
+    VALUE(T5CON)    = 0;
+    VALUE(TMR5)     = 0;
+    VALUE(PR5)      = 0xffff;
 }
 
 static unsigned io_read32(pic32_t *s, unsigned offset, const char **namep)
@@ -830,6 +849,25 @@ static unsigned io_read32(pic32_t *s, unsigned offset, const char **namep)
     STORAGE(SPI4BRGSET); *bufp = 0; break;
     STORAGE(SPI4BRGINV); *bufp = 0; break;
 
+    /*-------------------------------------------------------------------------
+     * Timers.
+     */
+    STORAGE(T1CON); break;
+    STORAGE(TMR1); break;
+    STORAGE(PR1); break;
+    STORAGE(T2CON); break;
+    STORAGE(TMR2); break;
+    STORAGE(PR2); break;
+    STORAGE(T3CON); break;
+    STORAGE(TMR3); break;
+    STORAGE(PR3); break;
+    STORAGE(T4CON); break;
+    STORAGE(TMR4); break;
+    STORAGE(PR4); break;
+    STORAGE(T5CON); break;
+    STORAGE(TMR5); break;
+    STORAGE(PR5); break;
+
     default:
         printf("--- Read 1f8%05x: peripheral register not supported\n",
             offset);
@@ -1188,6 +1226,25 @@ irq:    update_irq_status(s);
         pic32_spi_writebuf(s, 3, data);
         return;
     WRITEOP(SPI4BRG); return;                       // Baud rate
+
+    /*
+     * Timers 1-5.
+     */
+    WRITEOP(T1CON); return;
+    WRITEOP(TMR1); return;
+    WRITEOP(PR1); return;
+    WRITEOP(T2CON); return;
+    WRITEOP(TMR2); return;
+    WRITEOP(PR2); return;
+    WRITEOP(T3CON); return;
+    WRITEOP(TMR3); return;
+    WRITEOP(PR3); return;
+    WRITEOP(T4CON); return;
+    WRITEOP(TMR4); return;
+    WRITEOP(PR4); return;
+    WRITEOP(T5CON); return;
+    WRITEOP(TMR5); return;
+    WRITEOP(PR5); return;
 
     default:
         printf("--- Write %08x to 1f8%05x: peripheral register not supported\n",

--- a/hw/mips/pic32mx.h
+++ b/hw/mips/pic32mx.h
@@ -875,12 +875,28 @@
 #define PIC32_NVMCON_WR         0x00008000
 
 /*
- * Timer2 registers
+ * Timer registers
  */
+#define T1CON           PIC32_R (0x0600)
+#define T1CONSET        PIC32_R (0x0608)
+#define TMR1            PIC32_R (0x0610)
+#define PR1             PIC32_R (0x0620)
 #define T2CON           PIC32_R (0x0800)
 #define T2CONSET        PIC32_R (0x0808)
 #define TMR2            PIC32_R (0x0810)
 #define PR2             PIC32_R (0x0820)
+#define T3CON           PIC32_R (0x0a00)
+#define T3CONSET        PIC32_R (0x0a08)
+#define TMR3            PIC32_R (0x0a10)
+#define PR3             PIC32_R (0x0a20)
+#define T4CON           PIC32_R (0x0c00)
+#define T4CONSET        PIC32_R (0x0c08)
+#define TMR4            PIC32_R (0x0c10)
+#define PR4             PIC32_R (0x0c20)
+#define T5CON           PIC32_R (0x0e00)
+#define T5CONSET        PIC32_R (0x0e08)
+#define TMR5            PIC32_R (0x0e10)
+#define PR5             PIC32_R (0x0e20)
 
 /*
  * Output compare registers


### PR DESCRIPTION
Only timer2 was stubbed out on the pic32mx.  This adds the missing stubs for timers 1-5.
Prior:
```
❯ ./mipsel-softmmu/qemu-system-mipsel   -machine pic32mx7-explorer16   -nographic -monitor none   -serial stdio   -kernel  ~/nuttx/wrk/nuttx/nuttx.hex 
Board: Microchip Explorer16
Processor: M4K
RAM size: 128 kbytes
Load file: '/home/bashton/nuttx/wrk/nuttx/nuttx.hex', 250268 bytes
nx_start: Entry
```
After:
```
❯ ./mipsel-softmmu/qemu-system-mipsel   -machine pic32mx7-explorer16   -nographic -monitor none   -serial stdio   -kernel  ~/nuttx/wrk/nuttx/nuttx.hex 
Board: Microchip Explorer16
Processor: M4K
RAM size: 128 kbytes
Load file: '/home/bashton/nuttx/wrk/nuttx/nuttx.hex', 250268 bytes
nx_start: Entry
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
uart_register: Registering /dev/ttyS1
nx_start_application: Starting init thread

: ttShell (NnxSH) NuttX_sta-1rt0.0.1
nsh> CPU0: Beginning Idle Loop
```